### PR TITLE
vertico-directory: Fix vertico-directory-up edgecase

### DIFF
--- a/extensions/vertico-directory.el
+++ b/extensions/vertico-directory.el
@@ -66,7 +66,8 @@
   "Delete directory before point."
   (interactive)
   (when (and (eq (char-before) ?/)
-             (vertico-directory--completing-file-p))
+             (vertico-directory--completing-file-p)
+             (not (eq (point) (minibuffer-prompt-end))))
     (save-excursion
       (goto-char (1- (point)))
       (when (search-backward "/" (minibuffer-prompt-end) t)


### PR DESCRIPTION
If the prompt ends with "/" it gives out an "Invalid search bound (wrong
side of point)" error, since it moves back one char and then tries to
search backwards with a bound after the point.