### PR TITLE
vertico-indexed: Handle vertico-exit-input correctly

### DIFF
--- a/extensions/vertico-indexed.el
+++ b/extensions/vertico-indexed.el
@@ -52,7 +52,7 @@
                    prefix)
            suffix index start))
 
-(defun vertico-indexed--handle-prefix (orig &optional _)
+(defun vertico-indexed--handle-prefix (orig &rest args)
   "Handle prefix argument before calling ORIG function."
   (if current-prefix-arg
       (let ((vertico--index (+ vertico-indexed--min (prefix-numeric-value current-prefix-arg))))
@@ -61,7 +61,7 @@
                 (= vertico--total 0))
             (minibuffer-message "Out of range")
           (funcall orig)))
-    (funcall orig)))
+    (apply orig args)))
 
 ;;;###autoload
 (define-minor-mode vertico-indexed-mode


### PR DESCRIPTION
If vertico-indexed-mode is enabled, vertico-exit-input works the same as
vertico-exit instead of exiting with input. This simple patch fixes this.
