### PR TITLE
Add highlight-directory option

### DIFF
--- a/vertico.el
+++ b/vertico.el
@@ -59,6 +59,10 @@
   "Maximal number of candidates to show."
   :type 'integer)
 
+(defcustom vertico-highlight-directories nil
+  "Enable displaying directories using a different face."
+  :type 'boolean)
+
 (defcustom vertico-resize resize-mini-windows
   "How to resize the Vertico minibuffer window.
 See `resize-mini-windows' for documentation."
@@ -101,6 +105,9 @@ See `resize-mini-windows' for documentation."
 
 (defface vertico-current '((t :inherit highlight :extend t))
   "Face used to highlight the currently selected candidate.")
+
+(defface vertico-directory '((t :inherit dired-directory))
+  "Face used to highlight directories in file candidate lists.")
 
 (defvar vertico-map
   (let ((map (make-composed-keymap nil minibuffer-local-map)))
@@ -482,6 +489,8 @@ The function is configured by BY, BSIZE, BINDEX, BPRED and PRED."
 
 (defun vertico--format-candidate (cand prefix suffix index _start)
   "Format CAND given PREFIX, SUFFIX and INDEX."
+  (when (and vertico-highlight-directories (string-suffix-p "/" cand))
+    (add-face-text-property 0 (length cand) 'vertico-directory 'append cand))
   (setq cand (concat prefix cand suffix "\n")
         cand (vertico--flatten-string 'invisible (vertico--flatten-string 'display cand)))
   (when (= index vertico--index)


### PR DESCRIPTION
Hi,

I wanted to have a way to quickly tell whether a given candidate was a directory or a file when completing for files. While Marginalia helps with that, it's all the way to the right-hand side of the screen, hence this PR

I've added an option and a user settable face to use for highlighting directories.
It seems to be working well, at least in my case.

I'm not very familiar with elisp in general so please forgive me if there's something incorrect, or that should be done in a better way, like the logic for detecting whether the current candidate is a directory or not. I know there are better suited functions for that, but I've seen that approach used elsewhere and it sounded like a good enough way also considering that it might be on the hot path and accessing the file system all the time there might not be the best.

Also, I don't know if this is the best place to add something like that or whether it should be in one of the extensions sub-packets or somewhere else altogether.

In essence, feel free to reshape, improve or just close this PR if you're not happy with it.