### PR TITLE
Remove while-no-input-ignore-events workaround

### DIFF
--- a/vertico.el
+++ b/vertico.el
@@ -426,9 +426,7 @@ The function is configured by BY, BSIZE, BINDEX, BPRED and PRED."
         (if (and (eq 'file (completion-metadata-get metadata 'category))
                  (or (vertico--remote-p content) (vertico--remote-p default-directory)))
             (vertico--recompute-candidates pt content metadata)
-          ;; bug#38024: Icomplete uses `while-no-input-ignore-events' to repair updating issues
-          (let ((while-no-input-ignore-events '(selection-request))
-                (non-essential t))
+          (let ((non-essential t))
             (while-no-input (vertico--recompute-candidates pt content metadata))))
       ('nil (abort-recursive-edit))
       (`(,base ,total ,def-missing ,index ,candidates ,groups ,all-groups ,hl)


### PR DESCRIPTION
Originally borrowed from icomplete, removed from Emacs in
[6265e9349f40f74cc275b3b2f1995d220519b3bd](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=6265e9349f40f74cc275b3b2f1995d220519b3bd)

Discussion: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=38024

This is the last thing that I know of to close #115 (at least for my specific repro)