### PR TITLE
vertico-indexed: Fix vertico-exit

### DIFF
--- a/extensions/vertico-indexed.el
+++ b/extensions/vertico-indexed.el
@@ -54,7 +54,7 @@
                    prefix)
            suffix index start))
 
-(defun vertico-indexed--handle-prefix (&rest orig)
+(defun vertico-indexed--handle-prefix (orig &rest args)
   "Handle prefix argument before applying ORIG function."
   (if (and current-prefix-arg (called-interactively-p t))
       (let ((vertico--index (+ vertico-indexed--min (prefix-numeric-value current-prefix-arg))))
@@ -62,8 +62,8 @@
                 (> vertico--index vertico-indexed--max)
                 (= vertico--total 0))
             (minibuffer-message "Out of range")
-          (apply orig)))
-    (apply orig)))
+          (funcall orig)))
+    (apply orig args)))
 
 ;;;###autoload
 (define-minor-mode vertico-indexed-mode


### PR DESCRIPTION
With vertico-indexed-mode, vertico-exit doesn't abide by the numeric prefix arg
any more. This patch is a simple fix.
