### PR TITLE
vertico-directory-up: Expand tilde when going up from ~/

### DIFF
--- a/extensions/vertico-directory.el
+++ b/extensions/vertico-directory.el
@@ -73,6 +73,9 @@
              (vertico-directory--completing-file-p))
     (save-excursion
       (goto-char (1- (point)))
+      (when (eq (char-before) ?~)
+        (delete-char -1)
+        (insert (expand-file-name "~")))
       (when (search-backward "/" (minibuffer-prompt-end) t)
         (delete-region (1+ (point)) (point-max))
         t))))


### PR DESCRIPTION
Hi! I enjoy vertico-directory from GNU ELPA. 😆 After using vertico-directory, one thing I want is the tilde (~/; home directory) expansion. In Ido, when point is just after `~/`, DEL will expand the tilde and then go up the directory (it results /home/ usually Linux).