### PR TITLE
[vertico-grid] Fix wrong docstring of usage.

### DIFF
--- a/extensions/vertico-grid.el
+++ b/extensions/vertico-grid.el
@@ -28,11 +28,11 @@
 
 ;; This package is a Vertico extension providing a grid display.
 ;;
-;; The mode can be enabled globally or via `vertico-multiform-mode' per
+;; The mode can be enabled globally or via `vertico-grid-mode' per
 ;; command or completion category. Alternatively the grid display can be
-;; toggled temporarily if `vertico-multiform-mode' is enabled:
+;; toggled via local key-binding:
 ;;
-;; (define-key vertico-map "\M-G" #'vertico-multiform-grid)
+;; (define-key vertico-map "\M-G" #'vertico-grid-mode)
 
 ;;; Code:
 


### PR DESCRIPTION
`vertico-multiform-grid` doesn't existed in this file.