### PR TITLE
vertico-multiform: fixed a typo in example

### DIFF
--- a/extensions/vertico-multiform.el
+++ b/extensions/vertico-multiform.el
@@ -40,7 +40,7 @@
 ;;            (execute-extended-command flat)))
 ;;
 ;;    (setq vertico-multiform-categories
-;;          '((file buffer grid))
+;;          '((file buffer grid)
 ;;            (imenu (:not indexed mouse))
 ;;            (symbol (vertico-sort-function . vertico-sort-alpha))))
 ;;


### PR DESCRIPTION
Without this commit, it's not a valid alist.