### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -581,5 +581,5 @@ define a custom completion style which sets in only for remote files!
    'completion-styles-alist
    '(basic-remote basic-remote-try-completion basic-remote-all-completions nil))
   (setq completion-styles '(orderless)
-        completion-category-overrides '((file (styles basic-remote partial-completion))))
+        completion-category-overrides '((file (styles basic-remote orderless))))
 #+end_src


### PR DESCRIPTION
Update the advanced tramp hostname completion example to default to orderless completion for files, except in the case of remote files.

Using the previous partial-completion seems to provide no benefit over the simple example defined above which uses partial-completion.  I suspect this was a typo.