### PR TITLE
vertico-directory: Pacify compiler warning about `backward-delete-char'

### DIFF
--- a/extensions/vertico-directory.el
+++ b/extensions/vertico-directory.el
@@ -87,7 +87,7 @@
   "Delete N directories or chars before point."
   (interactive "p")
   (unless (and (eq (char-before) ?/) (vertico-directory-up n))
-    (backward-delete-char n)))
+    (delete-char (- n))))
 
 ;;;###autoload
 (defun vertico-directory-delete-word (&optional n)


### PR DESCRIPTION
* extensions/vertico-directory.el (vertico-directory-delete-char): Use `delete-char' instead of `backward-delete-char' which is intended for interactive use.