### PR TITLE
Add customizable restore function to vertico-buffer

### DIFF
--- a/extensions/vertico-buffer.el
+++ b/extensions/vertico-buffer.el
@@ -70,6 +70,19 @@
                   (side . bottom)))
           (sexp :tag "Other")))
 
+(defcustom vertico-buffer-restore-function
+  'set-window-buffer
+  "Function to display the original buffer in the Vertico buffer's window.
+
+This function is called during teardown of Vertico sessions.  It
+receives two arguments: the window and the buffer to be
+displayed."
+  :group 'vertico
+  :type '(choice
+          (const :tag "Set window buffer explicitly"
+                 'set-window-buffer)
+          (function :tag "Other")))
+
 (defun vertico-buffer--redisplay (win)
   "Redisplay window WIN."
   (when-let (mbwin (active-minibuffer-window))
@@ -124,7 +137,7 @@
                       (set-window-parameter win 'no-other-window now)
                       (set-window-parameter win 'no-delete-other-windows ndow)
                       (set-window-dedicated-p win nil)
-                      (set-window-buffer win old-buf))
+                      (funcall vertico-buffer-restore-function win old-buf))
                     (when vertico-buffer-hide-prompt
                       (set-window-vscroll nil 0))
                     (remove-hook 'minibuffer-exit-hook sym)))))


### PR DESCRIPTION
`vertico-buffer` currently uses `set-window-buffer` during cleanup to re-display the Vertico window's original buffer. In some configurations, this can cause point to "jump" when a buffer is open in more than one window. For example, try this configuration:

```elisp
;; (add-to-list 'load-path ...)
(require 'use-package)
(use-package vertico :ensure t :config (vertico-mode 1))
(use-package
  vertico-buffer
  :ensure nil
  :after vertico
  :custom
  (vertico-buffer-display-action '(display-buffer-same-window))
  :config
  (vertico-buffer-mode))
(use-package evil :ensure t :config (evil-mode))
```

To reproduce the issue:
- open a file in emacs
- split the window so the file buffer is visible in two windows
- move point in one of the windows
- run any `completing-read` command
- complete the command (or just press `C-g`) and notice that point has jumped to its position from the other window

In this case, there's some sort of interaction with `evil-mode` that causes the issue, i.e. this seems like a "local" issue that doesn't need to be fixed generally in Vertico. But as far as I can tell it's not possible to fix it by e.g. advising evil or disabling and re-enabling `evil-mode` in hooks, so I ended up fixing locally with the following `minibuffer-setup-hook`:

```elisp
(lambda ()
  (when vertico-buffer-mode
    (let ((vertico-buffer--destroy
           (seq-find
            (lambda (elt)
              (and
               (symbolp elt)
               (string= "vertico-buffer--destroy" (symbol-name elt))))
            (default-value 'minibuffer-exit-hook))))
      (advice-add
       vertico-buffer--destroy
       :around
       (lambda (orig-fn &rest args)
         (advice-add
          'set-window-buffer
          :override
          (lambda (win buf &optional keep-margins)
            ;; Remove the override immediately, as `quit-window' calls `set-window-buffer'
            ;; internally.
            (advice-remove
             'set-window-buffer "vertico-buffer--destroy")
            (if (with-selected-window win
                  (eq major-mode 'minibuffer-mode))
                (quit-window win)
              (set-window-buffer win buf keep-margins)))
          '((name . "vertico-buffer--destroy")))
         (apply orig-fn args)
         ;; Ensure the advice gets removed in case `set-window-buffer' wasn't actually
         ;; called.
         (advice-remove
          'set-window-buffer "vertico-buffer--destroy"))))))
```

With this PR, the issue could be worked around using:
```elisp
(setq vertico-buffer-restore-function
  (lambda (win buf)
    (if (with-selected-window win (eq major-mode 'minibuffer-mode))
      (quit-window win)
      (set-window-buffer win buf))))
```

So, while a workaround is currently possible, this change would expose the relevant functionality more directly.

Happy to make any changes to the custom definition or structure if you think something else would be more appropriate. Thanks for this amazing package.