### PR TITLE
Fix range check in vertico-indexed

### DIFF
--- a/extensions/vertico-indexed.el
+++ b/extensions/vertico-indexed.el
@@ -61,7 +61,7 @@
                     (- (prefix-numeric-value prefix-arg)
                        vertico-indexed-start))))
         (if (and (>= index vertico-indexed--min)
-                 (< index vertico-indexed--max)
+                 (<= index vertico-indexed--max)
                  (/= vertico--total 0))
             (setq vertico--index index)
           (minibuffer-message "Out of range")


### PR DESCRIPTION
When using vertico-indexed, completing the last item with the universal argument is consistently failing with an "Out of range" error.  It appears `vertico-indexed--max` should be inclusive.