### PR TITLE
vertico-buffer: Use display-buffer-in-direction for "Below target buf…

### DIFF
--- a/extensions/vertico-buffer.el
+++ b/extensions/vertico-buffer.el
@@ -47,8 +47,9 @@
           (const :tag "Reuse some window"
                  (display-buffer-reuse-window))
           (const :tag "Below target buffer"
-                 (display-buffer-below-selected
-                  (window-height . ,(+ 3 vertico-count))))
+                 (display-buffer-in-direction
+                  (window-height . ,(+ 3 vertico-count))
+                  (direction . below)))
           (const :tag "Bottom of frame"
                  (display-buffer-at-bottom
                   (window-height . ,(+ 3 vertico-count))))


### PR DESCRIPTION
Display action display-buffer-below-selected conflicts with dired-mark-pop-up appears if dired-no-confirm is nil.

## BEFORE: display-buffer-below-selected

```emacs-lisp
(set-frame-width nil 80)
(vertico-buffer-mode 0)
(setq vertico-buffer-display-action
      `(display-buffer-below-selected
        (window-height . ,(+ 3 vertico-count))))
(vertico-buffer-mode 1)
(setq dired-no-confirm nil)
(pop-to-buffer (find-file-noselect user-emacs-directory))
(delete-other-windows)
(dired-unmark-all-marks)
(dired-mark-files-in-region (progn (goto-char (point-min)) (point)) (progn (forward-line 6) (point)))
(dired-do-copy)
```

<img width="648" alt="vertico-buffer_display-buffer-below-selected" src="https://user-images.githubusercontent.com/12934757/226105063-327a4c1c-6829-4c52-992f-0776cf7a6aaa.png">
<img width="1208" alt="vertico-buffer_display-buffer-below-selected_wide" src="https://user-images.githubusercontent.com/12934757/226105098-c7faf27b-35bb-42c2-b0ed-ef35ed3815e3.png">


## AFTER: display-buffer-in-direction

```emacs-lisp
(set-frame-width nil 80)
(vertico-buffer-mode 0)
(setq vertico-buffer-display-action
      `(display-buffer-in-direction
        (window-height . ,(+ 3 vertico-count))
        (direction . below)))
(vertico-buffer-mode 1)
(setq dired-no-confirm nil)
(pop-to-buffer (find-file-noselect user-emacs-directory))
(delete-other-windows)
(dired-unmark-all-marks)
(dired-mark-files-in-region (progn (goto-char (point-min)) (point)) (progn (forward-line 6) (point)))
(dired-do-copy)
```

<img width="648" alt="vertico-buffer_display-buffer-in-direction-below" src="https://user-images.githubusercontent.com/12934757/226105422-fdea287f-6a89-430c-bbf6-5d8d942dd439.png">
<img width="1208" alt="vertico-buffer_display-buffer-in-direction-below_wide" src="https://user-images.githubusercontent.com/12934757/226105432-452e4893-c993-402f-b769-bdcd088e984b.png">
<img width="1208" alt="vertico-buffer_display-buffer-in-direction-below_wide-stb" src="https://user-images.githubusercontent.com/12934757/226105938-eef0efc8-e388-48ca-894b-24e4dd7f9934.png">
