### PR TITLE
Fix code typo in tramp workaround: partial-completion -> orderless

### DIFF
--- a/README.org
+++ b/README.org
@@ -663,9 +663,9 @@ the completion style overrides for the file completion category.
         completion-category-overrides '((file (styles basic partial-completion))))
 #+end_src
 
-For users who are familiar with the =completion-style= machinery and who want to
-dig a bit deeper. You may also define a custom completion style which sets in
-only for remote files. This way =orderless= will stay the preferred style in most
+This disadvantage of this solution is that you loose the ability to match substrings
+within the filename. For a complete workaround define a custom completion style which
+kicks in only for remote files. This way =orderless= will stay the preferred style in most
 cases.
 
 #+begin_src emacs-lisp
@@ -679,5 +679,5 @@ cases.
    'completion-styles-alist
    '(basic-remote basic-remote-try-completion basic-remote-all-completions nil))
   (setq completion-styles '(orderless basic)
-        completion-category-overrides '((file (styles basic-remote partial-completion))))
+        completion-category-overrides '((file (styles basic-remote orderless))))
 #+end_src


### PR DESCRIPTION
In the last code snippet orderless is most surely what was intended and not partial-completion style. 

I also modified the docs guided by my own struggle. First I just put the simple [workaround](https://github.com/minad/vertico/blob/93aab3f3c99a1dcb2bbf8e2637f926f0333d643a/README.org?plain=1#L663) without reading the "for users who want to dig dipper" part (who wants to dig deeper on the first setup anyway?). 

Then I got annoyed with the lack of sub-string completion in files and started searching for issues and README with patterns like "within file" and "substring file". No luck. Finally read the trump part proper and figured it out. Hence the doc change the way it is proposed here.

AFAIC the simple workaround need not even be in the docs.  Most users would probably want the complete solution anyhow. But I wonder if the tramp problem could be eventually fixed on the orderless side though. 