### PR TITLE
Add an option to allow the vertico prompt to never be selected

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -2,6 +2,11 @@
 #+author: Daniel Mendler
 #+language: en
 
+* Development
+
+- =vertico-preselect=: Add =never-prompt= configuration choice to
+  entirely disallow the selection of the prompt.
+
 * Version 1.7 (2024-01-23)
 
 - =vertico-buffer-mode=: Simplify mode line format.

--- a/vertico.el
+++ b/vertico.el
@@ -67,8 +67,13 @@
   "Configure if the prompt or first candidate is preselected.
 - prompt: Always select the prompt.
 - first: Always select the first candidate.
-- directory: Like first, but select the prompt if it is a directory."
-  :type '(choice (const prompt) (const first) (const directory)))
+- directory: Like first, but select the prompt if it is a directory.
+- never-prompt: Disallow the selection of the prompt entirely."
+  :type '(choice
+          (const prompt)
+          (const first)
+          (const directory)
+          (const never-prompt)))
 
 (defcustom vertico-scroll-margin 2
   "Number of lines at the top and bottom when scrolling.
@@ -352,9 +357,10 @@ The function is configured by BY, BSIZE, BINDEX, BPRED and PRED."
       (vertico--candidates . ,all)
       (vertico--total . ,(length all))
       (vertico--hilit . ,(or hl #'identity))
-      (vertico--allow-prompt . ,(or def-missing (eq vertico-preselect 'prompt)
-                                    (memq minibuffer--require-match
-                                          '(nil confirm confirm-after-completion))))
+      (vertico--allow-prompt . ,(and (not (eq vertico-preselect 'never-prompt))
+                                     (or def-missing (eq vertico-preselect 'prompt)
+                                         (memq minibuffer--require-match
+                                               '(nil confirm confirm-after-completion)))))
       (vertico--lock-candidate . ,lock)
       (vertico--groups . ,(cadr groups))
       (vertico--all-groups . ,(or (caddr groups) vertico--all-groups))


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

First off I want to say thank you for the excellent suite of packages
and the effort that has been put in to have them work cooperatively
with the Emacs ecosystem as a whole.

Compared to how long I've used other completion selection frameworks,
I'm a relatively recent adopter of Vertico, having only used it for a
year. One of the issues I've faced during that time is that sometimes
"mysteriously" I am able to select the prompt and sometimes I am
not. Why that is actually makes a lot of sense and isn't really a
mystery but it does feel inconsistent and relatively hard to build
muscle memory for, especially with `vertico-cycle` non-nil.

With that in mind what I typically use `vertico-exit-input` to select
a non-candidate completion, it feels like this "always works", and is
an easy habit to form. When using a `vertico-exit-input` based
workflow though the need to select a prompt feels redundant and can
still hamper with my ability to cycle backwards though candidates.

</details>

<details open>
<summary><h2> Solution </h2></summary>

Create a new user option `vertico-allow-prompt` that when non-nil will
allow the prompt to be selected; when nil the prompt will not be
selectable.

---

Adding the functionality directly to Vertico seems the cleanest but I
understand that it might have other repercussions both in adding
"clutter" to the user facing options and by changing the appearance of
the prompt. Perhaps a advice to `vertico--goto` could be used but I
haven't experimented with that yet since I tend to shy away from
advice where possible.

</details>


<details open>
<summary><h2> Testing Done </h2></summary>

I've been happily using this enhancement for months at this point.

</details>