### PR TITLE
Replace `when-let` by `when-let*`, fix emacs obsolete warning

### DIFF
--- a/extensions/vertico-grid.el
+++ b/extensions/vertico-grid.el
@@ -109,7 +109,7 @@ When scrolling beyond this limit, candidates may be truncated."
   "Grid display for Vertico."
   :global t :group 'vertico
   ;; Shrink current minibuffer window
-  (when-let ((win (active-minibuffer-window)))
+  (when-let* ((win (active-minibuffer-window)))
     (unless (frame-root-window-p win)
       (window-resize win (- (window-pixel-height win)) nil nil 'pixelwise)))
   (cl-callf2 rassq-delete-all vertico-grid-map minor-mode-map-alist)
@@ -157,7 +157,7 @@ When scrolling beyond this limit, candidates may be truncated."
     (cl-loop for row from 0 to (1- (min vertico-count vertico--total)) collect
              (let ((line (list "\n")))
                (cl-loop for col from (1- vertico-grid--columns) downto 0 do
-                        (when-let ((cand (nth (+ row (* col vertico-count)) cands)))
+                        (when-let* ((cand (nth (+ row (* col vertico-count)) cands)))
                           (push cand line)
                           (when (> col 0)
                             (push vertico-grid-separator line)


### PR DESCRIPTION
Fix emacs 31.0.50's warning:
```
../../.emacs.d/elpaca/builds/vertico/vertico-grid.el: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead. [2 times]
```

