### PR TITLE
Have `vertico-directory-delete-char` support regions

### DIFF
--- a/extensions/vertico-directory.el
+++ b/extensions/vertico-directory.el
@@ -91,17 +91,33 @@ Exit with current input if prefix ARG is given."
 (defun vertico-directory-delete-char (&optional n)
   "Delete N directories or chars before point."
   (interactive "p")
-  (unless (and (eq (char-before) ?/) (vertico-directory-up n))
-    (delete-char (- n))))
+  (cond ((and (use-region-p)
+	      delete-active-region
+	      (= n 1))
+	 ;; If a region is active, kill or delete it.
+	 (if (eq delete-active-region 'kill)
+	     (kill-region (region-beginning) (region-end) 'region)
+           (funcall region-extract-function 'delete-only)))
+        ((not (and (eq (char-before) ?/) (vertico-directory-up n)))
+         ;; If the previous character is not `/' delete the character
+          (delete-char (- n)))))
 
 ;;;###autoload
 (defun vertico-directory-delete-word (&optional n)
   "Delete N directories or words before point."
   (interactive "p")
-  (unless (and (eq (char-before) ?/) (vertico-directory-up n))
-    (let ((pt (point)))
-      (backward-word n)
-      (delete-region pt (point)))))
+  (cond ((and (use-region-p)
+	      delete-active-region
+	      (= n 1))
+	 ;; If a region is active, kill or delete it.
+	 (if (eq delete-active-region 'kill)
+	     (kill-region (region-beginning) (region-end) 'region)
+           (funcall region-extract-function 'delete-only)))
+        ((not (and (eq (char-before) ?/) (vertico-directory-up n)))
+         ;; If the previous character is not `/' delete the word
+         (let ((pt (point)))
+           (backward-word n)
+           (delete-region pt (point))))))
 
 ;;;###autoload
 (defun vertico-directory-tidy ()


### PR DESCRIPTION
Hi @minad, I hope the new year is finding you well.

## Problem

When using `vertico-directory-delete-char` I find it intuitive that
selecting a region doesn't delete that region, and that it doesn't
behave as I would typically expect.

### Behavior

Let us use `|` to designate the mark and `^` to designate the point.

If I am using the `find-file` command and type some extra characters
`testingmore-characters` my prompt may look like:
`Find File: ~/testingmore-characters^`

If I then select a region it may look like:
`Find File: ~/testing^more-characters|`

When I press `DEL` to run the `vertico-directory-delete-char` function
I then see: `Find File: ~/testin^more-characters`. The `g` is deleted
but the region remains.

Instead I expect the selected region to be deleted and to instead see:
`Find File: ~/testing^`

## Solution

My proposed solution is to have special behavior when
`(region-active-p)`. In that case I propose that we run the user's
default `DEL` key. In my case that is `delete-backward-char` which I
would be happy to hard code as well.

## Notes

 - I would happy to do something similar for `vertico-directory-delete-word`
   if we think that would make sense for consistency.
 - Another thing to note is that in this case we prioritize deleting a region 
   over going up a directory when a region is selected and the previous
   character is a `/` that felt good to me but am happy to tweak it.