### PR TITLE
vertico--setup: Disable continuation and truncation glyphs locally

### DIFF
--- a/vertico.el
+++ b/vertico.el
@@ -606,6 +606,11 @@ the stack trace is shown in the *Messages* buffer."
 
 (cl-defgeneric vertico--setup ()
   "Setup completion UI."
+  (let ((display-table (make-display-table)))
+    (set-char-table-parent display-table standard-display-table)
+    (set-display-table-slot display-table 'truncation (make-glyph-code ? ))
+    (set-display-table-slot display-table 'wrap (make-glyph-code ? ))
+    (setq buffer-display-table display-table))
   (when (boundp 'pixel-scroll-precision-mode)
     (setq-local pixel-scroll-precision-mode nil))
   (setq-local scroll-margin 0


### PR DESCRIPTION
`vertico--setup` currently disables continuation and truncation indicators in the fringe. This makes sense because Marginalia annotations often exceed the window width, causing lines to get truncated. When fringes are disabled, Emacs instead displays the glyphs `\` and `$` in the rightmost column to indicate continuation and truncation. Vertico does not disable those indicators, leading to inconsistent behavior when fringes are disabled. This patch updates `vertico--setup` to replace those glyphs in the `buffer-display-table` with the space character so that they are not visible.