### PR TITLE
Fix missing bracket in `vertico-directory.el' commentary example

### DIFF
--- a/extensions/vertico-directory.el
+++ b/extensions/vertico-directory.el
@@ -38,7 +38,7 @@
 ;; `vertico-multiform-mode'.
 ;;
 ;; (setq vertico-multiform-categories
-;;       '((file (:keymap . vertico-directory-map)))
+;;       '((file (:keymap . vertico-directory-map))))
 ;; (vertico-multiform-mode)
 ;;
 ;; Furthermore a cleanup function for shadowed file paths is provided.


### PR DESCRIPTION
@minad Thank you for your excellent work on vertico, consult, etc!

I noticed that there is a missing bracket in the multiform example in the commentary at the beginning of  `vertico-directory.el`.