### PR TITLE
Use "current-minibuffer-command" in vertico-multiform-commands lookup

### DIFF
--- a/extensions/vertico-multiform.el
+++ b/extensions/vertico-multiform.el
@@ -125,7 +125,9 @@ The keys in LIST can be symbols or regexps."
                    (pop vertico-multiform--stack))))
     (add-hook 'minibuffer-exit-hook exit)
     (add-hook 'context-menu-functions #'vertico-multiform--display-menu nil t)
-    (dolist (x (cdr (or (vertico-multiform--lookup this-command vertico-multiform-commands)
+    (dolist (x (cdr (or (and (boundp 'current-minibuffer-command)
+			     (vertico-multiform--lookup current-minibuffer-command vertico-multiform-commands))
+                        (vertico-multiform--lookup this-command vertico-multiform-commands)
                         (vertico-multiform--lookup cat vertico-multiform-categories))))
       (pcase x
         (`(:keymap . ,key)


### PR DESCRIPTION
As mentioned in bug#45392[1], read-from-minibuffer will have this-command = exit-minibuffer, which isn’t very useful for filtering. The alternative is "current-minibuffer-command" which should always have the originating command name.

[1]: https://lists.gnu.org/archive/html/bug-gnu-emacs/2021-01/msg01463.html